### PR TITLE
Feature/abstract connection

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    postgres_upsert (3.0.0)
+    postgres_upsert (4.0.0)
       activerecord (>= 3.0.0)
       pg (~> 0.17.0)
       rails (>= 3.0.0)

--- a/lib/postgres_upsert/active_record.rb
+++ b/lib/postgres_upsert/active_record.rb
@@ -7,7 +7,11 @@ module ActiveRecord
     # * You can map fields from the file to different fields in the table using a map in the options hash
     # * For further details on usage take a look at the README.md
     def self.pg_upsert path_or_io, options = {}
-      PostgresUpsert::Writer.new(table_name, path_or_io, options).write
+      PostgresUpsert::Writer.new(ActiveRecord::Base.connection.raw_connection,
+                                 table_name,
+                                 path_or_io,
+                                 options)
+      .write
     end
   end
 end

--- a/lib/postgres_upsert/writer.rb
+++ b/lib/postgres_upsert/writer.rb
@@ -110,9 +110,13 @@ module PostgresUpsert
     def select_string_for_insert
       columns = @columns_list.clone
       str = get_columns_string(columns)
-      str << ",'#{DateTime.now.utc}'" if column_names.include?("created_at")
-      str << ",'#{DateTime.now.utc}'" if column_names.include?("updated_at")
+      str << ",'#{now}'" if column_names.include?("created_at")
+      str << ",'#{now}'" if column_names.include?("updated_at")
       str
+    end
+
+    def now
+      @now ||= Time.now.utc
     end
 
     def select_string_for_create
@@ -165,7 +169,7 @@ module PostgresUpsert
       command = @columns_list.map do |col|
         "\"#{col}\" = t.\"#{col}\""
       end
-      command << "\"updated_at\" = '#{DateTime.now.utc}'" if column_names.include?("updated_at")
+      command << "\"updated_at\" = '#{now}'" if column_names.include?("updated_at")
       "SET #{command.join(',')}"
     end
 

--- a/lib/postgres_upsert/writer.rb
+++ b/lib/postgres_upsert/writer.rb
@@ -60,7 +60,7 @@ module PostgresUpsert
           AND indisprimary
         sql
 
-        pg_result = conn.execute query
+        pg_result = conn.raw_connection.exec_params query
         pg_result.each{ |row| return row['attname'] }
       end
     end
@@ -68,7 +68,7 @@ module PostgresUpsert
     def column_names
       @column_names ||= begin
         query = "SELECT * FROM information_schema.columns WHERE TABLE_NAME = '#{@table_name}'"
-        pg_result = conn.execute query
+        pg_result = conn.raw_connection.exec_params query
         pg_result.map{ |row| row['column_name'] }
       end
     end
@@ -150,7 +150,7 @@ module PostgresUpsert
     end
 
     def update_from_temp_table
-      conn.execute <<-SQL
+      conn.raw_connection.exec_params <<-SQL
         UPDATE #{quoted_table_name} AS d
           #{update_set_clause}
           FROM #{@temp_table_name} as t
@@ -170,7 +170,7 @@ module PostgresUpsert
     def insert_from_temp_table
       columns_string = columns_string_for_insert
       select_string = select_string_for_insert
-      conn.execute <<-SQL
+      conn.raw_connection.exec_params <<-SQL
         INSERT INTO #{quoted_table_name} (#{columns_string})
           SELECT #{select_string}
           FROM #{@temp_table_name} as t
@@ -184,7 +184,7 @@ module PostgresUpsert
 
     def create_temp_table
       columns_string = select_string_for_create
-      conn.execute <<-SQL
+      conn.raw_connection.exec_params <<-SQL
         SET client_min_messages=WARNING;
         DROP TABLE IF EXISTS #{@temp_table_name};
 
@@ -194,7 +194,7 @@ module PostgresUpsert
     end
 
     def drop_temp_table
-      conn.execute <<-SQL
+      conn.raw_connection.exec_params <<-SQL
         DROP TABLE #{@temp_table_name} 
       SQL
     end

--- a/lib/postgres_upsert/writer.rb
+++ b/lib/postgres_upsert/writer.rb
@@ -1,8 +1,14 @@
 module PostgresUpsert
 
   class Writer
+    attr_reader :conn
 
-    def initialize(table_name, source, options = {})
+    # @param PG::Connection conn
+    # @param String table_name
+    # @param String|IO source
+    # @param Hash options
+    def initialize(conn, table_name, source, options = {})
+      @conn = conn
       @table_name = table_name
       @options = options.reverse_merge({
         :delimiter => ",", 
@@ -40,10 +46,6 @@ module PostgresUpsert
     end
 
   private
-
-    def conn
-      @conn ||= ActiveRecord::Base.connection.raw_connection
-    end
 
     def primary_key
       @primary_key ||= begin

--- a/lib/postgres_upsert/writer.rb
+++ b/lib/postgres_upsert/writer.rb
@@ -125,7 +125,7 @@ module PostgresUpsert
     end
 
     def quoted_table_name
-      @quoted_table_name ||= conn.quote_table_name(@table_name)
+      @quoted_table_name ||= PG::Connection::quote_ident(@table_name)
     end
 
     def generate_temp_table_name

--- a/postgres_upsert.gemspec
+++ b/postgres_upsert.gemspec
@@ -5,7 +5,7 @@ $:.unshift lib unless $:.include?(lib)
 
 Gem::Specification.new do |s|
   s.name = "postgres_upsert"
-  s.version = "3.0.0"
+  s.version = "4.0.0"
 
   s.platform    = Gem::Platform::RUBY
   s.required_ruby_version     = ">= 1.8.7"

--- a/spec/active_record_mixin_spec.rb
+++ b/spec/active_record_mixin_spec.rb
@@ -1,0 +1,27 @@
+require File.expand_path(File.dirname(__FILE__) + '/spec_helper')
+
+class TestModel < ActiveRecord::Base; end
+
+describe "active record extension" do
+  before do
+    ActiveRecord::Base.establish_connection(
+      :adapter  => "postgresql",
+      :host     => "localhost",
+      :username => "postgres",
+      :password => "postgres",
+      :port     => 5432,
+      :database => "ar_pg_copy_test"
+    )
+  end
+
+  it "should call writer with correct set of arguments" do
+    dbl = double
+    PostgresUpsert::Writer.should_receive(:new)
+      .with(ActiveRecord::Base.connection.raw_connection, 'test_models', 'path/to/file.csv', {})
+      .and_return(dbl)
+
+    dbl.should_receive(:write)
+
+    TestModel.pg_upsert 'path/to/file.csv'
+  end
+end

--- a/spec/fixtures/reserved_word_model.rb
+++ b/spec/fixtures/reserved_word_model.rb
@@ -1,5 +1,0 @@
-require 'postgres_upsert'
-
-class ReservedWordModel < ActiveRecord::Base
-end
-

--- a/spec/fixtures/test_model.rb
+++ b/spec/fixtures/test_model.rb
@@ -1,4 +1,0 @@
-require 'postgres_upsert'
-
-class TestModel < ActiveRecord::Base
-end

--- a/spec/fixtures/three_column.rb
+++ b/spec/fixtures/three_column.rb
@@ -1,4 +1,0 @@
-require 'postgres_upsert'
-
-class ThreeColumn < ActiveRecord::Base
-end

--- a/spec/pg_upsert_binary_spec.rb
+++ b/spec/pg_upsert_binary_spec.rb
@@ -2,7 +2,14 @@ require File.expand_path(File.dirname(__FILE__) + '/spec_helper')
 
 describe "pg_upsert from file with binary data" do
   before(:each) do
-    ActiveRecord::Base.connection.execute %{
+    @conn ||= PG::Connection.open(
+      :host     => "localhost",
+      :user     => "postgres",
+      :password => "postgres",
+      :port     => 5432,
+      :dbname   => "ar_pg_copy_test"
+    )
+    @conn.exec_params %{
       TRUNCATE TABLE test_models;
       SELECT setval('test_models_id_seq', 1, false);
     }

--- a/spec/pg_upsert_binary_spec.rb
+++ b/spec/pg_upsert_binary_spec.rb
@@ -16,25 +16,33 @@ describe "pg_upsert from file with binary data" do
   end
 
   before do
-    DateTime.stub(:now).and_return (DateTime.parse("2012-01-01").utc)
+    PostgresUpsert::Writer.any_instance.stub(:now).and_return Time.parse("2012-01-01").utc
   end
 
   def timestamp
-    DateTime.now.utc.to_s
+    Time.parse("2012-01-01").utc
+  end
+
+  def sample_record
+    pg_result = @conn.exec_params 'SELECT * FROM test_models LIMIT 1;'
+    pg_result.map{ |row| row }.first.tap do |fields|
+      fields['id'] = fields['id'].to_i
+      fields['created_at'] = Time.parse(fields['created_at']).utc
+      fields['updated_at'] = Time.parse(fields['updated_at']).utc
+    end
   end
 
   it "imports from file if path is passed without field_map" do
-    TestModel.pg_upsert File.expand_path('spec/fixtures/2_col_binary_data.dat'), :format => :binary, columns: [:id, :data]
+    PostgresUpsert::Writer.new(@conn, 'test_models', File.expand_path('spec/fixtures/2_col_binary_data.dat'),
+                               :format => :binary, columns: [:id, :data]).write
 
-    expect(
-      TestModel.first.attributes
-    ).to include('data' => 'text', 'created_at' => timestamp, 'updated_at' => timestamp)
+    expect(sample_record).to include('data' => 'text', 'created_at' => timestamp, 'updated_at' => timestamp)
   end
 
   it "throws an error when importing binary file without columns list" do
     # Since binary data never has a header row, we'll require explicit columns list
     expect{
-      TestModel.pg_upsert File.expand_path('spec/fixtures/2_col_binary_data.dat'), :format => :binary
+      PostgresUpsert::Writer.new(@conn, 'test_models', File.expand_path('spec/fixtures/2_col_binary_data.dat'), :format => :binary).write
     }.to raise_error "Either the :columns option or :header => true are required"
   end
 

--- a/spec/pg_upsert_binary_spec.rb
+++ b/spec/pg_upsert_binary_spec.rb
@@ -16,7 +16,7 @@ describe "pg_upsert from file with binary data" do
   end
 
   before do
-    PostgresUpsert::Writer.any_instance.stub(:now).and_return Time.parse("2012-01-01").utc
+    PostgresUpsert::Writer.any_instance.stub(:now).and_return timestamp
   end
 
   def timestamp

--- a/spec/pg_upsert_csv_spec.rb
+++ b/spec/pg_upsert_csv_spec.rb
@@ -17,132 +17,141 @@ describe "pg_upsert from file with CSV format" do
   end
 
   before do
-    DateTime.stub_chain(:now, :utc).and_return (DateTime.parse("2012-01-01").utc)
+    PostgresUpsert::Writer.any_instance.stub(:now).and_return Time.parse("2012-01-01").utc
   end
 
   def timestamp
-    DateTime.now.utc
+    Time.parse("2012-01-01").utc
+  end
+
+  def sample_record(table_name = 'test_models', id = 1)
+    pg_result = @conn.exec_params "SELECT * FROM #{table_name} WHERE id = #{id};"
+    pg_result.map{ |row| row }.first.tap do |fields|
+      return if fields.nil?
+      fields['id'] = fields['id'].to_i
+      fields['created_at'] = Time.parse(fields['created_at']).utc if fields['created_at']
+      fields['updated_at'] = Time.parse(fields['updated_at']).utc if fields['updated_at']
+    end
   end
 
   it "should import from file if path is passed without field_map" do
-    TestModel.pg_upsert File.expand_path('spec/fixtures/comma_with_header.csv')
+    PostgresUpsert::Writer.new(@conn, 'test_models', File.expand_path('spec/fixtures/comma_with_header.csv')).write
     expect(
-      TestModel.first.attributes
+      sample_record
     ).to include('data' => 'test data 1', 'created_at' => timestamp, 'updated_at' => timestamp)
   end
 
   it "correctly handles delimiters in content" do
-    TestModel.pg_upsert File.expand_path('spec/fixtures/comma_with_header_and_comma_values.csv')
+    PostgresUpsert::Writer.new(@conn, 'test_models', File.expand_path('spec/fixtures/comma_with_header_and_comma_values.csv')).write
     expect(
-      TestModel.first.attributes
+      sample_record
     ).to include('data' => 'test, the data 1', 'created_at' => timestamp, 'updated_at' => timestamp)
   end
 
   it "throws error if csv is malformed" do
     expect{
-      TestModel.pg_upsert File.expand_path('spec/fixtures/comma_with_header_and_unquoted_comma.csv')
+      PostgresUpsert::Writer.new(@conn, 'test_models', File.expand_path('spec/fixtures/comma_with_header_and_unquoted_comma.csv')).write
     }.to raise_error
   end
 
   it "throws error if the csv has mixed delimiters" do
     expect{
-      TestModel.pg_upsert File.expand_path('spec/fixtures/tab_with_error.csv'), :delimiter => "\t"
+      PostgresUpsert::Writer.new(@conn, 'test_models', File.expand_path('spec/fixtures/tab_with_error.csv'), :delimiter => "\t").write
     }.to raise_error
   end
 
   it "should import from IO without field_map" do
-    TestModel.pg_upsert File.open(File.expand_path('spec/fixtures/comma_with_header.csv'), 'r')
+    PostgresUpsert::Writer.new(@conn, 'test_models', File.open(File.expand_path('spec/fixtures/comma_with_header.csv'), 'r')).write
     expect(
-      TestModel.first.attributes
+      sample_record
     ).to include('data' => 'test data 1', 'created_at' => timestamp, 'updated_at' => timestamp)
   end
 
   it "should import with custom delimiter from path" do
-    TestModel.pg_upsert File.expand_path('spec/fixtures/semicolon_with_header.csv'), :delimiter => ';'
+    PostgresUpsert::Writer.new(@conn, 'test_models', File.expand_path('spec/fixtures/semicolon_with_header.csv'), :delimiter => ';').write
     expect(
-      TestModel.first.attributes
+      sample_record
     ).to include('data' => 'test data 1', 'created_at' => timestamp, 'updated_at' => timestamp)
   end
 
   it "should import with custom delimiter from IO" do
-    TestModel.pg_upsert File.open(File.expand_path('spec/fixtures/semicolon_with_header.csv'), 'r'), :delimiter => ';'
+    PostgresUpsert::Writer.new(@conn, 'test_models', File.open(File.expand_path('spec/fixtures/semicolon_with_header.csv'), 'r'), :delimiter => ';').write
     expect(
-      TestModel.first.attributes
+      sample_record
     ).to include('data' => 'test data 1', 'created_at' => timestamp, 'updated_at' => timestamp)
   end
 
   it "should not expect a header when :header is false" do
-    TestModel.pg_upsert(File.open(File.expand_path('spec/fixtures/comma_without_header.csv'), 'r'), :header => false, :columns => [:id,:data])
-
+    PostgresUpsert::Writer.new(@conn, 'test_models', File.open(File.expand_path('spec/fixtures/comma_without_header.csv'), 'r'), :header => false, :columns => [:id,:data]).write
     expect(
-      TestModel.first.attributes
+      sample_record
     ).to include('data' => 'test data 1', 'created_at' => timestamp, 'updated_at' => timestamp)
   end
 
   it "should be able to map the header in the file to diferent column names" do
-    TestModel.pg_upsert(File.open(File.expand_path('spec/fixtures/tab_with_different_header.csv'), 'r'), :delimiter => "\t", :map => {'cod' => 'id', 'info' => 'data'})
+    PostgresUpsert::Writer.new(@conn, 'test_models', File.open(File.expand_path('spec/fixtures/tab_with_different_header.csv'), 'r'), :delimiter => "\t", :map => {'cod' => 'id', 'info' => 'data'}).write
 
     expect(
-      TestModel.first.attributes
+      sample_record
     ).to include('data' => 'test data 1', 'created_at' => timestamp, 'updated_at' => timestamp)
   end
 
   it "should be able to map the header in the file to diferent column names with custom delimiter" do
-    TestModel.pg_upsert(File.open(File.expand_path('spec/fixtures/semicolon_with_different_header.csv'), 'r'), :delimiter => ';', :map => {'cod' => 'id', 'info' => 'data'})
+    PostgresUpsert::Writer.new(@conn, 'test_models', File.open(File.expand_path('spec/fixtures/semicolon_with_different_header.csv'), 'r'), :delimiter => ';', :map => {'cod' => 'id', 'info' => 'data'}).write
 
     expect(
-      TestModel.first.attributes
+      sample_record
     ).to include('data' => 'test data 1', 'created_at' => timestamp, 'updated_at' => timestamp)
   end
 
   it "should ignore empty lines" do
-    TestModel.pg_upsert(File.open(File.expand_path('spec/fixtures/tab_with_extra_line.csv'), 'r'), :delimiter => "\t")
+    PostgresUpsert::Writer.new(@conn, 'test_models', File.open(File.expand_path('spec/fixtures/tab_with_extra_line.csv'), 'r'), :delimiter => "\t").write
 
     expect(
-      TestModel.first.attributes
+      sample_record
     ).to include('data' => 'test data 1', 'created_at' => timestamp, 'updated_at' => timestamp)
   end
 
   it "should not create timestamps when the model does not include them" do
-    ReservedWordModel.pg_upsert File.expand_path('spec/fixtures/reserved_words.csv'), :delimiter => "\t"
+    PostgresUpsert::Writer.new(@conn, 'reserved_word_models', File.expand_path('spec/fixtures/reserved_words.csv'), :delimiter => "\t").write
 
     expect(
-      ReservedWordModel.first.attributes
+      sample_record('reserved_word_models', 1)
     ).to eq("group"=>"group name", "id"=>1, "select"=>"test select")
   end
 
   context "upserting data to handle inserts and creates" do
-    let(:original_created_at) {5.days.ago.utc}
+    let(:original_created_at) { (Date.today - 5).to_time.utc }
 
     before(:each) do
-      TestModel.create(id: 1, data: "From the before time, in the long long ago", :created_at => original_created_at)
+      @conn.exec_params "INSERT INTO test_models (id, data, created_at) VALUES(1, 'From the before time, in the long long ago', '#{original_created_at}')"
     end
 
     it "should not violate primary key constraint" do
       expect{
-        TestModel.pg_upsert File.expand_path('spec/fixtures/comma_with_header.csv')
+        PostgresUpsert::Writer.new(@conn, 'test_models', File.expand_path('spec/fixtures/comma_with_header.csv')).write
       }.to_not raise_error
     end
 
     it "should upsert (update existing records and insert new records)" do
-      TestModel.pg_upsert File.expand_path('spec/fixtures/tab_with_two_lines.csv'), :delimiter => "\t"
+      PostgresUpsert::Writer.new(@conn, 'test_models', File.expand_path('spec/fixtures/tab_with_two_lines.csv'), :delimiter => "\t").write
 
       expect(
-        TestModel.find(1).attributes
+        sample_record
       ).to eq("id"=>1, "data"=>"test data 1", "created_at" => original_created_at, "updated_at" => timestamp)
       expect(
-        TestModel.find(2).attributes
+        sample_record('test_models', 2)
       ).to eq("id"=>2, "data"=>"test data 2", "created_at" => timestamp, "updated_at" => timestamp)
     end
 
     it "should require columns option if no header" do
       expect{
-        TestModel.pg_upsert File.expand_path('spec/fixtures/2_col_binary_data.dat'), :format => :binary
+        PostgresUpsert::Writer.new(@conn, 'test_models', File.expand_path('spec/fixtures/2_col_binary_data.dat'), :format => :binary).write
       }.to raise_error("Either the :columns option or :header => true are required")
     end
 
     it "should clean up the temp table after completion" do
-      TestModel.pg_upsert File.expand_path('spec/fixtures/tab_with_two_lines.csv'), :delimiter => "\t"
+      PostgresUpsert::Writer.new(@conn, 'test_models', File.expand_path('spec/fixtures/tab_with_two_lines.csv'), :delimiter => "\t").write
       pg_result = @conn.exec_params <<-sql
         SELECT table_schema,table_name
         FROM information_schema.tables
@@ -155,63 +164,59 @@ describe "pg_upsert from file with CSV format" do
 
     it "should gracefully drop the temp table if it already exists" do
       @conn.exec_params "CREATE TEMP TABLE test_models_temp (LIKE test_models);"
-      TestModel.pg_upsert File.expand_path('spec/fixtures/tab_with_two_lines.csv'), :delimiter => "\t"
+      PostgresUpsert::Writer.new(@conn, 'test_models', File.expand_path('spec/fixtures/tab_with_two_lines.csv'), :delimiter => "\t").write
 
       expect(
-        TestModel.find(1).attributes
+        sample_record
       ).to eq("id"=>1, "data"=>"test data 1", "created_at" => original_created_at, "updated_at" => timestamp)
       expect(
-        TestModel.find(2).attributes
+        sample_record('test_models', 2)
       ).to eq("id"=>2, "data"=>"test data 2", "created_at" => timestamp, "updated_at" => timestamp)
     end
 
     it "should be able to copy using custom set of columns" do
-      ThreeColumn.create(id: 1, data: "old stuff", extra: "neva change!", created_at: original_created_at)
-      ThreeColumn.pg_upsert(File.open(File.expand_path('spec/fixtures/tab_only_data.csv'), 'r'), :delimiter => "\t", :columns => ["id", "data"])
+      @conn.exec_params "INSERT INTO three_columns (id, data, extra, created_at) VALUES(1, 'old stuff', 'neva change!', '#{original_created_at}')"
+      PostgresUpsert::Writer.new(@conn, 'three_columns', File.open(File.expand_path('spec/fixtures/tab_only_data.csv'), 'r'), :delimiter => "\t", :columns => ["id", "data"]).write
 
       expect(
-        ThreeColumn.first.attributes
+        sample_record('three_columns', 1)
       ).to eq('id' => 1, 'data' => 'test data 1', 'extra' => "neva change!", 'created_at' => original_created_at, 'updated_at' => timestamp)
     end
   end
 
   context 'overriding the comparison column' do
     it 'updates records based the match column option if its passed in' do
-      three_col = ThreeColumn.create(id: 1, data: "old stuff", extra: "neva change!")
+      @conn.exec_params "INSERT INTO three_columns (id, data, extra) VALUES(1, 'old stuff', 'neva change!')"
       file = File.open(File.expand_path('spec/fixtures/no_id.csv'), 'r')
 
-
-      ThreeColumn.pg_upsert(file, :key_column => "data")
+      PostgresUpsert::Writer.new(@conn, 'three_columns', file, :key_column => "data").write
       expect(
-        three_col.reload.extra
+        sample_record('three_columns', 1)['extra']
       ).to eq("ABC: Always Be Changing.")
     end
 
     it 'inserts records if the passed match column doesnt exist' do
       file = File.open(File.expand_path('spec/fixtures/no_id.csv'), 'r')
 
-      ThreeColumn.pg_upsert(file, :key_column => "data")
+      PostgresUpsert::Writer.new(@conn, 'three_columns', file, :key_column => "data").write
       expect(
-        ThreeColumn.last.attributes
+        sample_record('three_columns', 1)
       ).to include("id" => 1, "data" => "old stuff", "extra" => "ABC: Always Be Changing.")
     end
   end
 
   context 'update only' do
-    let(:original_created_at) {5.days.ago.utc}
+    let(:original_created_at) { (Date.today - 5).to_time.utc }
     before(:each) do
-      TestModel.create(id: 1, data: "From the before time, in the long long ago", :created_at => original_created_at)
+      @conn.exec_params "INSERT INTO test_models (id, data, created_at) VALUES(1, 'From the before time, in the long long ago', '#{original_created_at}')"
     end
     it 'will only update and not insert if insert_only flag is passed.' do
-      TestModel.pg_upsert File.expand_path('spec/fixtures/tab_with_two_lines.csv'), :delimiter => "\t", :update_only => true
+      PostgresUpsert::Writer.new(@conn, 'test_models', File.expand_path('spec/fixtures/tab_with_two_lines.csv'), :delimiter => "\t", :update_only => true).write
 
       expect(
-        TestModel.find(1).attributes
-      ).to eq("id"=>1, "data"=>"test data 1", "created_at" => original_created_at  , "updated_at" => timestamp)
-      expect{
-        TestModel.find(2)
-      }.to raise_error(ActiveRecord::RecordNotFound)
-
+        sample_record
+      ).to eq("id"=>1, "data"=>"test data 1", "created_at" => original_created_at, "updated_at" => timestamp)
+      expect(sample_record('test_models', 2)).to be_nil
     end
 
   end

--- a/spec/pg_upsert_csv_spec.rb
+++ b/spec/pg_upsert_csv_spec.rb
@@ -2,14 +2,7 @@ require File.expand_path(File.dirname(__FILE__) + '/spec_helper')
 
 describe "pg_upsert from file with CSV format" do
   before(:each) do
-    @conn ||= PG::Connection.open(
-      :host     => "localhost",
-      :user     => "postgres",
-      :password => "postgres",
-      :port     => 5432,
-      :dbname   => "ar_pg_copy_test"
-    )
-    @conn.exec_params %{
+    conn.exec_params %{
       TRUNCATE TABLE test_models;
       TRUNCATE TABLE three_columns;
       SELECT setval('test_models_id_seq', 1, false);
@@ -25,7 +18,7 @@ describe "pg_upsert from file with CSV format" do
   end
 
   def sample_record(table_name = 'test_models', id = 1)
-    pg_result = @conn.exec_params "SELECT * FROM #{table_name} WHERE id = #{id};"
+    pg_result = conn.exec_params "SELECT * FROM #{table_name} WHERE id = #{id};"
     pg_result.map{ |row| row }.first.tap do |fields|
       return if fields.nil?
       fields['id'] = fields['id'].to_i
@@ -35,14 +28,14 @@ describe "pg_upsert from file with CSV format" do
   end
 
   it "should import from file if path is passed without field_map" do
-    PostgresUpsert::Writer.new(@conn, 'test_models', File.expand_path('spec/fixtures/comma_with_header.csv')).write
+    PostgresUpsert::Writer.new(conn, 'test_models', File.expand_path('spec/fixtures/comma_with_header.csv')).write
     expect(
       sample_record
     ).to include('data' => 'test data 1', 'created_at' => timestamp, 'updated_at' => timestamp)
   end
 
   it "correctly handles delimiters in content" do
-    PostgresUpsert::Writer.new(@conn, 'test_models', File.expand_path('spec/fixtures/comma_with_header_and_comma_values.csv')).write
+    PostgresUpsert::Writer.new(conn, 'test_models', File.expand_path('spec/fixtures/comma_with_header_and_comma_values.csv')).write
     expect(
       sample_record
     ).to include('data' => 'test, the data 1', 'created_at' => timestamp, 'updated_at' => timestamp)
@@ -50,46 +43,46 @@ describe "pg_upsert from file with CSV format" do
 
   it "throws error if csv is malformed" do
     expect{
-      PostgresUpsert::Writer.new(@conn, 'test_models', File.expand_path('spec/fixtures/comma_with_header_and_unquoted_comma.csv')).write
+      PostgresUpsert::Writer.new(conn, 'test_models', File.expand_path('spec/fixtures/comma_with_header_and_unquoted_comma.csv')).write
     }.to raise_error
   end
 
   it "throws error if the csv has mixed delimiters" do
     expect{
-      PostgresUpsert::Writer.new(@conn, 'test_models', File.expand_path('spec/fixtures/tab_with_error.csv'), :delimiter => "\t").write
+      PostgresUpsert::Writer.new(conn, 'test_models', File.expand_path('spec/fixtures/tab_with_error.csv'), :delimiter => "\t").write
     }.to raise_error
   end
 
   it "should import from IO without field_map" do
-    PostgresUpsert::Writer.new(@conn, 'test_models', File.open(File.expand_path('spec/fixtures/comma_with_header.csv'), 'r')).write
+    PostgresUpsert::Writer.new(conn, 'test_models', File.open(File.expand_path('spec/fixtures/comma_with_header.csv'), 'r')).write
     expect(
       sample_record
     ).to include('data' => 'test data 1', 'created_at' => timestamp, 'updated_at' => timestamp)
   end
 
   it "should import with custom delimiter from path" do
-    PostgresUpsert::Writer.new(@conn, 'test_models', File.expand_path('spec/fixtures/semicolon_with_header.csv'), :delimiter => ';').write
+    PostgresUpsert::Writer.new(conn, 'test_models', File.expand_path('spec/fixtures/semicolon_with_header.csv'), :delimiter => ';').write
     expect(
       sample_record
     ).to include('data' => 'test data 1', 'created_at' => timestamp, 'updated_at' => timestamp)
   end
 
   it "should import with custom delimiter from IO" do
-    PostgresUpsert::Writer.new(@conn, 'test_models', File.open(File.expand_path('spec/fixtures/semicolon_with_header.csv'), 'r'), :delimiter => ';').write
+    PostgresUpsert::Writer.new(conn, 'test_models', File.open(File.expand_path('spec/fixtures/semicolon_with_header.csv'), 'r'), :delimiter => ';').write
     expect(
       sample_record
     ).to include('data' => 'test data 1', 'created_at' => timestamp, 'updated_at' => timestamp)
   end
 
   it "should not expect a header when :header is false" do
-    PostgresUpsert::Writer.new(@conn, 'test_models', File.open(File.expand_path('spec/fixtures/comma_without_header.csv'), 'r'), :header => false, :columns => [:id,:data]).write
+    PostgresUpsert::Writer.new(conn, 'test_models', File.open(File.expand_path('spec/fixtures/comma_without_header.csv'), 'r'), :header => false, :columns => [:id,:data]).write
     expect(
       sample_record
     ).to include('data' => 'test data 1', 'created_at' => timestamp, 'updated_at' => timestamp)
   end
 
   it "should be able to map the header in the file to diferent column names" do
-    PostgresUpsert::Writer.new(@conn, 'test_models', File.open(File.expand_path('spec/fixtures/tab_with_different_header.csv'), 'r'), :delimiter => "\t", :map => {'cod' => 'id', 'info' => 'data'}).write
+    PostgresUpsert::Writer.new(conn, 'test_models', File.open(File.expand_path('spec/fixtures/tab_with_different_header.csv'), 'r'), :delimiter => "\t", :map => {'cod' => 'id', 'info' => 'data'}).write
 
     expect(
       sample_record
@@ -97,7 +90,7 @@ describe "pg_upsert from file with CSV format" do
   end
 
   it "should be able to map the header in the file to diferent column names with custom delimiter" do
-    PostgresUpsert::Writer.new(@conn, 'test_models', File.open(File.expand_path('spec/fixtures/semicolon_with_different_header.csv'), 'r'), :delimiter => ';', :map => {'cod' => 'id', 'info' => 'data'}).write
+    PostgresUpsert::Writer.new(conn, 'test_models', File.open(File.expand_path('spec/fixtures/semicolon_with_different_header.csv'), 'r'), :delimiter => ';', :map => {'cod' => 'id', 'info' => 'data'}).write
 
     expect(
       sample_record
@@ -105,7 +98,7 @@ describe "pg_upsert from file with CSV format" do
   end
 
   it "should ignore empty lines" do
-    PostgresUpsert::Writer.new(@conn, 'test_models', File.open(File.expand_path('spec/fixtures/tab_with_extra_line.csv'), 'r'), :delimiter => "\t").write
+    PostgresUpsert::Writer.new(conn, 'test_models', File.open(File.expand_path('spec/fixtures/tab_with_extra_line.csv'), 'r'), :delimiter => "\t").write
 
     expect(
       sample_record
@@ -113,7 +106,7 @@ describe "pg_upsert from file with CSV format" do
   end
 
   it "should not create timestamps when the model does not include them" do
-    PostgresUpsert::Writer.new(@conn, 'reserved_word_models', File.expand_path('spec/fixtures/reserved_words.csv'), :delimiter => "\t").write
+    PostgresUpsert::Writer.new(conn, 'reserved_word_models', File.expand_path('spec/fixtures/reserved_words.csv'), :delimiter => "\t").write
 
     expect(
       sample_record('reserved_word_models', 1)
@@ -124,17 +117,17 @@ describe "pg_upsert from file with CSV format" do
     let(:original_created_at) { (Date.today - 5).to_time.utc }
 
     before(:each) do
-      @conn.exec_params "INSERT INTO test_models (id, data, created_at) VALUES(1, 'From the before time, in the long long ago', '#{original_created_at}')"
+      conn.exec_params "INSERT INTO test_models (id, data, created_at) VALUES(1, 'From the before time, in the long long ago', '#{original_created_at}')"
     end
 
     it "should not violate primary key constraint" do
       expect{
-        PostgresUpsert::Writer.new(@conn, 'test_models', File.expand_path('spec/fixtures/comma_with_header.csv')).write
+        PostgresUpsert::Writer.new(conn, 'test_models', File.expand_path('spec/fixtures/comma_with_header.csv')).write
       }.to_not raise_error
     end
 
     it "should upsert (update existing records and insert new records)" do
-      PostgresUpsert::Writer.new(@conn, 'test_models', File.expand_path('spec/fixtures/tab_with_two_lines.csv'), :delimiter => "\t").write
+      PostgresUpsert::Writer.new(conn, 'test_models', File.expand_path('spec/fixtures/tab_with_two_lines.csv'), :delimiter => "\t").write
 
       expect(
         sample_record
@@ -146,13 +139,13 @@ describe "pg_upsert from file with CSV format" do
 
     it "should require columns option if no header" do
       expect{
-        PostgresUpsert::Writer.new(@conn, 'test_models', File.expand_path('spec/fixtures/2_col_binary_data.dat'), :format => :binary).write
+        PostgresUpsert::Writer.new(conn, 'test_models', File.expand_path('spec/fixtures/2_col_binary_data.dat'), :format => :binary).write
       }.to raise_error("Either the :columns option or :header => true are required")
     end
 
     it "should clean up the temp table after completion" do
-      PostgresUpsert::Writer.new(@conn, 'test_models', File.expand_path('spec/fixtures/tab_with_two_lines.csv'), :delimiter => "\t").write
-      pg_result = @conn.exec_params <<-sql
+      PostgresUpsert::Writer.new(conn, 'test_models', File.expand_path('spec/fixtures/tab_with_two_lines.csv'), :delimiter => "\t").write
+      pg_result = conn.exec_params <<-sql
         SELECT table_schema,table_name
         FROM information_schema.tables
         ORDER BY table_schema,table_name;
@@ -163,8 +156,8 @@ describe "pg_upsert from file with CSV format" do
     end
 
     it "should gracefully drop the temp table if it already exists" do
-      @conn.exec_params "CREATE TEMP TABLE test_models_temp (LIKE test_models);"
-      PostgresUpsert::Writer.new(@conn, 'test_models', File.expand_path('spec/fixtures/tab_with_two_lines.csv'), :delimiter => "\t").write
+      conn.exec_params "CREATE TEMP TABLE test_models_temp (LIKE test_models);"
+      PostgresUpsert::Writer.new(conn, 'test_models', File.expand_path('spec/fixtures/tab_with_two_lines.csv'), :delimiter => "\t").write
 
       expect(
         sample_record
@@ -175,8 +168,8 @@ describe "pg_upsert from file with CSV format" do
     end
 
     it "should be able to copy using custom set of columns" do
-      @conn.exec_params "INSERT INTO three_columns (id, data, extra, created_at) VALUES(1, 'old stuff', 'neva change!', '#{original_created_at}')"
-      PostgresUpsert::Writer.new(@conn, 'three_columns', File.open(File.expand_path('spec/fixtures/tab_only_data.csv'), 'r'), :delimiter => "\t", :columns => ["id", "data"]).write
+      conn.exec_params "INSERT INTO three_columns (id, data, extra, created_at) VALUES(1, 'old stuff', 'neva change!', '#{original_created_at}')"
+      PostgresUpsert::Writer.new(conn, 'three_columns', File.open(File.expand_path('spec/fixtures/tab_only_data.csv'), 'r'), :delimiter => "\t", :columns => ["id", "data"]).write
 
       expect(
         sample_record('three_columns', 1)
@@ -186,10 +179,10 @@ describe "pg_upsert from file with CSV format" do
 
   context 'overriding the comparison column' do
     it 'updates records based the match column option if its passed in' do
-      @conn.exec_params "INSERT INTO three_columns (id, data, extra) VALUES(1, 'old stuff', 'neva change!')"
+      conn.exec_params "INSERT INTO three_columns (id, data, extra) VALUES(1, 'old stuff', 'neva change!')"
       file = File.open(File.expand_path('spec/fixtures/no_id.csv'), 'r')
 
-      PostgresUpsert::Writer.new(@conn, 'three_columns', file, :key_column => "data").write
+      PostgresUpsert::Writer.new(conn, 'three_columns', file, :key_column => "data").write
       expect(
         sample_record('three_columns', 1)['extra']
       ).to eq("ABC: Always Be Changing.")
@@ -198,7 +191,7 @@ describe "pg_upsert from file with CSV format" do
     it 'inserts records if the passed match column doesnt exist' do
       file = File.open(File.expand_path('spec/fixtures/no_id.csv'), 'r')
 
-      PostgresUpsert::Writer.new(@conn, 'three_columns', file, :key_column => "data").write
+      PostgresUpsert::Writer.new(conn, 'three_columns', file, :key_column => "data").write
       expect(
         sample_record('three_columns', 1)
       ).to include("id" => 1, "data" => "old stuff", "extra" => "ABC: Always Be Changing.")
@@ -208,10 +201,10 @@ describe "pg_upsert from file with CSV format" do
   context 'update only' do
     let(:original_created_at) { (Date.today - 5).to_time.utc }
     before(:each) do
-      @conn.exec_params "INSERT INTO test_models (id, data, created_at) VALUES(1, 'From the before time, in the long long ago', '#{original_created_at}')"
+      conn.exec_params "INSERT INTO test_models (id, data, created_at) VALUES(1, 'From the before time, in the long long ago', '#{original_created_at}')"
     end
     it 'will only update and not insert if insert_only flag is passed.' do
-      PostgresUpsert::Writer.new(@conn, 'test_models', File.expand_path('spec/fixtures/tab_with_two_lines.csv'), :delimiter => "\t", :update_only => true).write
+      PostgresUpsert::Writer.new(conn, 'test_models', File.expand_path('spec/fixtures/tab_with_two_lines.csv'), :delimiter => "\t", :update_only => true).write
 
       expect(
         sample_record

--- a/spec/pg_upsert_csv_spec.rb
+++ b/spec/pg_upsert_csv_spec.rb
@@ -17,7 +17,7 @@ describe "pg_upsert from file with CSV format" do
   end
 
   before do
-    PostgresUpsert::Writer.any_instance.stub(:now).and_return Time.parse("2012-01-01").utc
+    PostgresUpsert::Writer.any_instance.stub(:now).and_return timestamp
   end
 
   def timestamp

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -12,14 +12,14 @@ RSpec.configure do |config|
     # we create a test database if it does not exist
     # I do not use database users or password for the tests, using ident authentication instead
     begin
-      @conn ||= PG::Connection.open(
+      conn = PG::Connection.open(
         :host     => "localhost",
         :user     => "postgres",
         :password => "postgres",
         :port     => 5432,
         :dbname   => "ar_pg_copy_test"
       )
-      @conn.exec_params %{
+      conn.exec_params %{
         SET client_min_messages TO warning;
         DROP TABLE IF EXISTS test_models;
         DROP TABLE IF EXISTS three_columns;
@@ -28,15 +28,6 @@ RSpec.configure do |config|
         CREATE TABLE three_columns (id serial PRIMARY KEY, data text, extra text, created_at timestamp with time zone, updated_at timestamp with time zone );
         CREATE TABLE reserved_word_models (id serial PRIMARY KEY, "select" text, "group" text);
       }
-      # TODO: make the gem truly AR agnostic and rewrite spec against PostgresUpsert::Writer but its active_record extension
-      ActiveRecord::Base.establish_connection(
-        :adapter  => "postgresql",
-        :host     => "localhost",
-        :username => "postgres",
-        :password => "postgres",
-        :port     => 5432,
-        :database => "ar_pg_copy_test"
-      )
     rescue Exception => e
       puts "Exception: #{e}"
       conn = PG::Connection.open(

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,5 +1,6 @@
 $LOAD_PATH.unshift(File.dirname(__FILE__))
 $LOAD_PATH.unshift(File.join(File.dirname(__FILE__), '..', 'lib'))
+require 'pg'
 require 'fixtures/test_model'
 require 'fixtures/three_column'
 require 'fixtures/reserved_word_model'
@@ -11,15 +12,14 @@ RSpec.configure do |config|
     # we create a test database if it does not exist
     # I do not use database users or password for the tests, using ident authentication instead
     begin
-      ActiveRecord::Base.establish_connection(
-        :adapter  => "postgresql",
+      @conn ||= PG::Connection.open(
         :host     => "localhost",
-        :username => "postgres",
+        :user     => "postgres",
         :password => "postgres",
         :port     => 5432,
-        :database => "ar_pg_copy_test"
+        :dbname   => "ar_pg_copy_test"
       )
-      ActiveRecord::Base.connection.execute %{
+      @conn.exec_params %{
         SET client_min_messages TO warning;
         DROP TABLE IF EXISTS test_models;
         DROP TABLE IF EXISTS three_columns;
@@ -28,18 +28,26 @@ RSpec.configure do |config|
         CREATE TABLE three_columns (id serial PRIMARY KEY, data text, extra text, created_at timestamp with time zone, updated_at timestamp with time zone );
         CREATE TABLE reserved_word_models (id serial PRIMARY KEY, "select" text, "group" text);
       }
-    rescue Exception => e
-      puts "Exception: #{e}"
+      # TODO: make the gem truly AR agnostic and rewrite spec against PostgresUpsert::Writer but its active_record extension
       ActiveRecord::Base.establish_connection(
         :adapter  => "postgresql",
         :host     => "localhost",
         :username => "postgres",
         :password => "postgres",
         :port     => 5432,
-        :database => "postgres"
+        :database => "ar_pg_copy_test"
       )
-      ActiveRecord::Base.connection.execute "DROP DATABASE IF EXISTS ar_pg_copy_test"
-      ActiveRecord::Base.connection.execute "CREATE DATABASE ar_pg_copy_test;"
+    rescue Exception => e
+      puts "Exception: #{e}"
+      conn = PG::Connection.open(
+        :host     => "localhost",
+        :user     => "postgres",
+        :password => "postgres",
+        :port     => 5432,
+        :dbname   => "postgres"
+      )
+      conn.exec_params "DROP DATABASE IF EXISTS ar_pg_copy_test;"
+      conn.exec_params "CREATE DATABASE ar_pg_copy_test;"
       retry
     end
   end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,9 +1,7 @@
 $LOAD_PATH.unshift(File.dirname(__FILE__))
 $LOAD_PATH.unshift(File.join(File.dirname(__FILE__), '..', 'lib'))
 require 'pg'
-require 'fixtures/test_model'
-require 'fixtures/three_column'
-require 'fixtures/reserved_word_model'
+require 'postgres_upsert'
 require 'rspec'
 require 'rspec/autorun'
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -5,18 +5,21 @@ require 'postgres_upsert'
 require 'rspec'
 require 'rspec/autorun'
 
+def conn
+  @conn ||= PG::Connection.open(
+    :host     => "localhost",
+    :user     => "postgres",
+    :password => "postgres",
+    :port     => 5432,
+    :dbname   => "ar_pg_copy_test"
+  )
+end
+
 RSpec.configure do |config|
   config.before(:suite) do
     # we create a test database if it does not exist
     # I do not use database users or password for the tests, using ident authentication instead
     begin
-      conn = PG::Connection.open(
-        :host     => "localhost",
-        :user     => "postgres",
-        :password => "postgres",
-        :port     => 5432,
-        :dbname   => "ar_pg_copy_test"
-      )
       conn.exec_params %{
         SET client_min_messages TO warning;
         DROP TABLE IF EXISTS test_models;


### PR DESCRIPTION
Changelist:
- work with instance of `PG::Connection` in the writer which has to be passed on initialize
- test `PostgresUpsert::Writer` rather than invoke it implicitly through AR mixin
- test the AR mixin separately