### PR TITLE
Adding license info to the gemspec.

### DIFF
--- a/postgres_upsert.gemspec
+++ b/postgres_upsert.gemspec
@@ -13,6 +13,7 @@ Gem::Specification.new do |s|
   s.date = "2014-09-12"
   s.description = "Uses Postgres's powerful COPY command to upsert large sets of data into ActiveRecord tables"
   s.email = "thestevemitchell@gmail.com"
+  s.license = "MIT"
   git_files            = `git ls-files`.split("\n") rescue ''
   s.files              = git_files
   s.test_files         = `git ls-files -- {test,spec,features}/*`.split("\n")


### PR DESCRIPTION
I'm working on the open source project [VersionEye](https://www.versioneye.com). By adding the license info to the gempspec it becomes available through the public RubyGems API and that way other tools like VersionEye can fetch it easier.